### PR TITLE
0.7.1 버전 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,10 @@ This project is licensed under the MIT License
   - **_/work/sort_** sort페이지 추가, 정렬 순서를 직접 입력하거나, 드래그앤 드롭으로 수정 가능
   - **_/work/write_, _/work/delete_, _/work/sort_** 관리자 페이지 간의 이동 방법을 로컬 네비게이션으로 변경, 네비게이션 내에 로그아웃 기능 추가
   - **_/work_** 이제 작업물들이 sort페이지에서 수정한 정렬 순서의 역순으로 표시됨
+
+  ***
+
+- **Version 0.7.0 (2024-10-18):**
+
+  - **_/work/sort_** 정렬 카테고리를 3개로 분리
+  - 데이터 상의 정렬 순서와 실제 표시되는 정렬 순서가 달랐던 버그 수정

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This project is licensed under the MIT License
 
   ***
 
-- **Version 0.7.0 (2024-10-18):**
+- **Version 0.7.1 (2024-10-18):**
 
   - **_/work/sort_** 정렬 카테고리를 3개로 분리
   - 데이터 상의 정렬 순서와 실제 표시되는 정렬 순서가 달랐던 버그 수정

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insan",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insan",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/feed/thumbnailFeed.tsx
+++ b/src/components/feed/thumbnailFeed.tsx
@@ -4,7 +4,7 @@ import Input from '@/components/input';
 import { VimeofeedProps, YoutubefeedProps } from '@/components/typings/components';
 import { Dispatch, SetStateAction, SyntheticEvent } from 'react';
 import { cls } from '@/libs/client/utils';
-import { OwnedVideoItems, WorkInfos } from '@/pages/work/work';
+import { OwnedVideoItems, VideoCategory, WorkInfos } from '@/pages/work/work';
 
 export const createInputChange = (
   setWorkInfos: Dispatch<SetStateAction<WorkInfos[]>>,
@@ -32,7 +32,13 @@ export const createInputChange = (
       } else if (type === 'radio') {
         setWorkInfos((p) =>
           p.map((arr) =>
-            arr.resourceId === dataset.resourceid ? { ...arr, category: value } : arr
+            arr.resourceId === dataset.resourceid
+              ? {
+                  ...arr,
+                  category: value as 'film' | 'short',
+                  order: dataset.prevCategory !== value ? 0 : arr.order,
+                }
+              : arr
           )
         );
       }
@@ -44,7 +50,7 @@ export const createInputChange = (
             title: value,
             description: dataset.description || '',
             date: dataset.date || '',
-            category: dataset.category || '',
+            category: (dataset.category as VideoCategory | undefined) || 'film',
             resourceId: dataset.resourceid || '',
             thumbnailLink: dataset.thumbnail || '',
             animatedThumbnailLink: dataset.animated_thumbnail || '',
@@ -71,7 +77,7 @@ export const onListItemClick = ({
     animatedThumbnailLink?: string;
   };
   setWorkInfos: Dispatch<SetStateAction<WorkInfos[]>>;
-  category?: string;
+  category?: VideoCategory;
 }) => {
   if (matchedWorkInfo) {
     setWorkInfos((prev) =>
@@ -84,7 +90,7 @@ export const onListItemClick = ({
         title: matchedOwnedVideo?.title || '',
         description: matchedOwnedVideo?.description || '',
         date: matchedOwnedVideo?.date || '',
-        category: category || '',
+        category: category || 'film',
         resourceId: currentVideoDetails?.resourceId || '',
         thumbnailLink: currentVideoDetails?.thumbnailLink || '',
         animatedThumbnailLink: currentVideoDetails?.animatedThumbnailLink || '',
@@ -142,7 +148,7 @@ export function VimeoThumbnailFeed({
                         setWorkInfos,
                         matchedWorkInfo,
                         matchedOwnedVideo,
-                        category: matchedOwnedVideo?.category,
+                        category: matchedOwnedVideo?.category || 'film',
                       });
                     }}
                     className={cls(
@@ -233,6 +239,7 @@ export function VimeoThumbnailFeed({
                         labelName="Film"
                         value="film"
                         data-resourceid={player_embed_url}
+                        data-prevcategory={matchedWorkInfo?.category}
                         onChange={inputChange}
                         checked={
                           matchedWorkInfo
@@ -254,6 +261,7 @@ export function VimeoThumbnailFeed({
                         labelName="Short"
                         value="short"
                         data-resourceid={player_embed_url}
+                        data-prevcategory={matchedWorkInfo?.category}
                         onChange={inputChange}
                         checked={
                           matchedWorkInfo

--- a/src/components/nav/postManagementLayout.tsx
+++ b/src/components/nav/postManagementLayout.tsx
@@ -1,34 +1,35 @@
-import { RefObject, ReactNode } from 'react';
+import { RefObject, ReactNode, Dispatch, SetStateAction } from 'react';
 import { cls } from '@/libs/client/utils';
 import { FlatformsCategory } from '@/pages/work/work';
 
-interface CategoryTabProps {
-  onFilmShortClick: () => void;
-  onOutsourceClick: () => void;
-  category: FlatformsCategory;
+interface Tabs<T> {
+  category: T;
+  name: string;
 }
 
-const CategoryTab = ({ onFilmShortClick, onOutsourceClick, category }: CategoryTabProps) => {
+interface CategoryTabProps<T> {
+  tabs: Tabs<T>[];
+  category: T;
+  onCategoryClick: (categoryLabel: T) => void;
+}
+
+const CategoryTab = <T,>({ tabs, category, onCategoryClick }: CategoryTabProps<T>) => {
   return (
     <div className="flex py-4">
-      <button
-        onClick={onFilmShortClick}
-        className={cls(
-          category === 'filmShort' ? 'text-palettered' : '',
-          'w-full flex justify-center items-center text-lg font-semibold hover:text-palettered'
-        )}
-      >
-        Film / Short
-      </button>
-      <button
-        onClick={onOutsourceClick}
-        className={cls(
-          category === 'outsource' ? 'text-palettered' : '',
-          'w-full flex justify-center items-center text-lg font-semibold hover:text-palettered'
-        )}
-      >
-        Outsource
-      </button>
+      {tabs.map((tab) => (
+        <button
+          key={tab.name}
+          onClick={() => {
+            onCategoryClick(tab.category);
+          }}
+          className={cls(
+            category === tab.category ? 'text-palettered' : '',
+            'w-full flex justify-center items-center text-lg font-semibold hover:text-palettered'
+          )}
+        >
+          {tab.name}
+        </button>
+      ))}
     </div>
   );
 };
@@ -41,31 +42,32 @@ const Title = ({ name }: { name: string }) => {
   );
 };
 
-export default function PostManagementLayout({
+export default function PostManagementLayout<T>({
   topElementRef,
   category,
   title,
-  onCategoryClick,
+  tabs,
+  setCategory,
+  reset,
   children,
 }: {
   topElementRef: RefObject<HTMLDivElement>;
-  category: FlatformsCategory;
+  category: T;
   title: string;
-  onCategoryClick: (categoryLabel: FlatformsCategory) => void;
+  tabs: Tabs<T>[];
+  setCategory: Dispatch<SetStateAction<T>>;
+  reset: () => void;
   children: ReactNode;
 }) {
+  const onCategoryClick = (categoryLabel: T) => {
+    if (category === categoryLabel) return;
+    setCategory(categoryLabel);
+    reset();
+  };
   return (
     <section ref={topElementRef} className="relative xl:px-40 sm:px-24 px-16">
       <Title name={title} />
-      <CategoryTab
-        category={category}
-        onFilmShortClick={() => {
-          onCategoryClick('filmShort');
-        }}
-        onOutsourceClick={() => {
-          onCategoryClick('outsource');
-        }}
-      />
+      <CategoryTab category={category} tabs={tabs} onCategoryClick={onCategoryClick} />
       {children}
     </section>
   );

--- a/src/components/nav/postManagementLayout.tsx
+++ b/src/components/nav/postManagementLayout.tsx
@@ -1,6 +1,5 @@
 import { RefObject, ReactNode, Dispatch, SetStateAction } from 'react';
 import { cls } from '@/libs/client/utils';
-import { FlatformsCategory } from '@/pages/work/work';
 
 interface Tabs<T> {
   category: T;
@@ -56,13 +55,13 @@ export default function PostManagementLayout<T>({
   title: string;
   tabs: Tabs<T>[];
   setCategory: Dispatch<SetStateAction<T>>;
-  reset: () => void;
+  reset: (agr: T) => void;
   children: ReactNode;
 }) {
   const onCategoryClick = (categoryLabel: T) => {
     if (category === categoryLabel) return;
     setCategory(categoryLabel);
-    reset();
+    reset(categoryLabel);
   };
   return (
     <section ref={topElementRef} className="relative xl:px-40 sm:px-24 px-16">

--- a/src/components/thumbnail.tsx
+++ b/src/components/thumbnail.tsx
@@ -1,14 +1,13 @@
-import { FlatformsCategory } from '@/pages/work/work';
 import Image from 'next/image';
 import { useState } from 'react';
 
-interface ThumbnailProps {
+interface ThumbnailProps<T> {
   src: { main: string; sub: string; alt: string };
   setPriority?: boolean;
-  category: FlatformsCategory;
+  category: T;
 }
 
-export default function Thumbnail({ category, src, setPriority }: ThumbnailProps) {
+export default function Thumbnail<T>({ category, src, setPriority }: ThumbnailProps<T>) {
   const [error, setError] = useState(false);
   const handleImageError = () => {
     setError(true);

--- a/src/libs/client/useInfiniteScroll.ts
+++ b/src/libs/client/useInfiniteScroll.ts
@@ -2,7 +2,7 @@
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { GapiItem } from '@/pages/work';
 import { ciIncludes, fetchData } from './utils';
-import { FlatformsCategory, VideoCollection, VimeoVideos } from '@/pages/work/work';
+import { FlatformsCategory, FlatformCollection, VimeoVideos } from '@/pages/work/work';
 
 interface UseInfiniteScrollFromFlatFormProps {
   category: FlatformsCategory;
@@ -12,9 +12,9 @@ interface UseInfiniteScrollFromFlatFormProps {
   searchResultsCount: number;
   initialNextPageToken: string;
   dependencies?: unknown[];
-  setSearchResults: Dispatch<SetStateAction<VideoCollection<VimeoVideos[], GapiItem[]>>>;
+  setSearchResults: Dispatch<SetStateAction<FlatformCollection<VimeoVideos[], GapiItem[]>>>;
   setPage: Dispatch<SetStateAction<number>>;
-  setList: Dispatch<SetStateAction<VideoCollection<VimeoVideos[], GapiItem[]>>>;
+  setList: Dispatch<SetStateAction<FlatformCollection<VimeoVideos[], GapiItem[]>>>;
   setFetchLoading: Dispatch<SetStateAction<boolean>>;
 }
 

--- a/src/pages/api/work/index.ts
+++ b/src/pages/api/work/index.ts
@@ -100,22 +100,24 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             client.works.upsert({
               where: { resourceId: el.resourceId },
               create: {
-                title: el.title,
-                resourceId: el.resourceId,
-                description: el.description,
-                category: el.category || 'film',
-                date: el.date || 'no-date',
-                thumbnailLink: el.thumbnailLink,
-                animationThumbnailLink: el.animatedThumbnailLink,
+                title: el.title || '',
+                resourceId: el.resourceId || '',
+                description: el.description || '',
+                category: el.category === undefined ? undefined : el.category || 'film',
+                date: el.date === undefined ? undefined : el.date || 'no-date',
+                thumbnailLink: el.thumbnailLink || '',
+                animationThumbnailLink: el.animatedThumbnailLink || '',
+                order: el.order || 0,
               },
               update: {
                 title: el.title,
                 resourceId: el.resourceId,
                 description: el.description,
-                category: el.category ? el.category : 'film',
-                date: el.date ? el.date : 'no-date',
+                category: el.category === undefined ? undefined : el.category || 'film',
+                date: el.date === undefined ? undefined : el.date || 'no-date',
                 thumbnailLink: el.thumbnailLink,
                 animationThumbnailLink: el.animatedThumbnailLink,
+                order: el.order,
               },
             })
           )

--- a/src/pages/api/work/list.ts
+++ b/src/pages/api/work/list.ts
@@ -15,16 +15,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (!page || !per_page) return;
   const take = +per_page;
   const skip = +per_page * (+page - 1);
-  const id = order === 'asc' ? 'asc' : 'desc';
+  const sortOrder = order === 'asc' ? 'asc' : 'desc';
   let works: VideoResponseItem = {
     film: [],
     short: [],
     outsource: [],
   };
-  const restOptions: { skip: number; take: number; orderBy: { id: typeof id } } = {
+  const restOptions: { skip: number; take: number; orderBy: { order: 'asc' | 'desc' } } = {
     skip,
     take,
-    orderBy: { id: 'desc' },
+    orderBy: { order: sortOrder },
   };
   if (category === 'film') {
     works.film = await client.works.findMany({

--- a/src/pages/work/delete.tsx
+++ b/src/pages/work/delete.tsx
@@ -303,8 +303,8 @@ export default function Delete({ initialWorks, initialHasNextPage }: InitialData
     dependencyArray: [page, fetchLoading, isGrid],
   });
 
-  const onCategoryChange = () => {
-    const oppositeCategory = category === 'filmShort' ? 'outsource' : 'filmShort';
+  const onCategoryChange = (categoryLabel: FlatformsCategory) => {
+    const oppositeCategory = categoryLabel === 'filmShort' ? 'outsource' : 'filmShort';
     setOnSelectedList(false);
     setDeleteIdList([]);
     setPage(2);
@@ -375,7 +375,6 @@ export default function Delete({ initialWorks, initialHasNextPage }: InitialData
             </div>
           </div>
         ) : null}
-
         <UtilButtons
           onViewSwitch={() => {
             setIsGrid((p) => !p);

--- a/src/pages/work/delete.tsx
+++ b/src/pages/work/delete.tsx
@@ -192,19 +192,6 @@ export default function Delete({ initialWorks, initialHasNextPage }: InitialData
     }
   }, [data]);
 
-  useEffect(() => {
-    setOnSelectedList(false);
-    setDeleteIdList([]);
-    setPage(2);
-    setSearchWordSnapShot('');
-    setSearchWord('');
-    setSearchResult((p) => ({
-      ...p,
-      [category === 'filmShort' ? 'outsource' : 'filmShort']:
-        list[category === 'filmShort' ? 'outsource' : 'filmShort'],
-    }));
-  }, [category]);
-
   const onSubmitDelete = () => {
     if (loading && deleteIdList.length > 0) return;
     send(deleteIdList, process.env.NEXT_PUBLIC_ODR_SECRET_TOKEN!);
@@ -316,9 +303,17 @@ export default function Delete({ initialWorks, initialHasNextPage }: InitialData
     dependencyArray: [page, fetchLoading, isGrid],
   });
 
-  const onCategoryClick = (categoryLabel: FlatformsCategory) => {
-    if (category === categoryLabel) return;
-    setCategory(categoryLabel);
+  const onCategoryChange = () => {
+    const oppositeCategory = category === 'filmShort' ? 'outsource' : 'filmShort';
+    setOnSelectedList(false);
+    setDeleteIdList([]);
+    setPage(2);
+    setSearchWordSnapShot('');
+    setSearchWord('');
+    setSearchResult((p) => ({
+      ...p,
+      [oppositeCategory]: list[oppositeCategory],
+    }));
   };
 
   return (
@@ -330,9 +325,14 @@ export default function Delete({ initialWorks, initialHasNextPage }: InitialData
     >
       <PostManagementLayout
         category={category}
-        onCategoryClick={onCategoryClick}
+        tabs={[
+          { category: 'filmShort', name: 'Film / Short' },
+          { category: 'outsource', name: 'OutSource' },
+        ]}
         title="삭제하기"
         topElementRef={topElementRef}
+        setCategory={setCategory}
+        reset={onCategoryChange}
       >
         <SearchForm onSearch={onSearch} setSearchWord={setSearchWord} searchWord={searchWord} />
         <div

--- a/src/pages/work/delete.tsx
+++ b/src/pages/work/delete.tsx
@@ -12,14 +12,14 @@ import { useRouter } from 'next/router';
 import { SyntheticEvent, useEffect, useRef, useState } from 'react';
 import ButtonsController from '@/components/butttons/buttonsController';
 import UtilButtons from '@/components/butttons/utilButtons';
-import { FlatformsCategory, VideoCollection, VideoResponseState } from '@/pages/work/work';
+import { FlatformsCategory, FlatformCollection, VideoResponseState } from '@/pages/work/work';
 import Thumbnail from '@/components/thumbnail';
 import PostManagementMenu from '@/components/nav/postManagementMenu';
 import PostManagementLayout from '@/components/nav/postManagementLayout';
 
 interface WorkProps {
   onClick: () => void;
-  searchResult: VideoCollection<Works[]>;
+  searchResult: FlatformCollection<Works[]>;
   category: FlatformsCategory;
   selected: boolean;
   resourceId: string;
@@ -150,8 +150,8 @@ const Work = ({
 };
 
 interface InitialData {
-  initialWorks: VideoCollection<Works[]>;
-  initialHasNextPage: VideoCollection<boolean>;
+  initialWorks: FlatformCollection<Works[]>;
+  initialHasNextPage: FlatformCollection<boolean>;
 }
 
 export default function Delete({ initialWorks, initialHasNextPage }: InitialData) {
@@ -160,12 +160,12 @@ export default function Delete({ initialWorks, initialHasNextPage }: InitialData
   const [category, setCategory] = useState<FlatformsCategory>('filmShort');
   const [searchWord, setSearchWord] = useState('');
   const [searchWordSnapShot, setSearchWordSnapShot] = useState('');
-  const [searchResult, setSearchResult] = useState<VideoCollection<Works[]>>(initialWorks);
-  const [searchResultSnapShot, setSearchResultSnapShot] = useState<VideoCollection<Works[]>>({
+  const [searchResult, setSearchResult] = useState<FlatformCollection<Works[]>>(initialWorks);
+  const [searchResultSnapShot, setSearchResultSnapShot] = useState<FlatformCollection<Works[]>>({
     filmShort: [],
     outsource: [],
   });
-  const [list, setList] = useState<VideoCollection<Works[]>>(initialWorks);
+  const [list, setList] = useState<FlatformCollection<Works[]>>(initialWorks);
   const [send, { loading, data, error }] = useDeleteRequest<{
     success: boolean;
   }>(`/api/work`);
@@ -179,7 +179,7 @@ export default function Delete({ initialWorks, initialHasNextPage }: InitialData
   const [onSelectedList, setOnSelectedList] = useState(false);
   const [fetchLoading, setFetchLoading] = useState(false);
   const [isGrid, setIsGrid] = useState(true);
-  const [hasNextPage, setHasNextPage] = useState<VideoCollection<boolean>>(initialHasNextPage);
+  const [hasNextPage, setHasNextPage] = useState<FlatformCollection<boolean>>(initialHasNextPage);
 
   useEffect(() => {
     if (data && data?.success) {

--- a/src/pages/work/index.tsx
+++ b/src/pages/work/index.tsx
@@ -1415,19 +1415,20 @@ export const getStaticProps: GetStaticProps = async () => {
     film: await client.works.findMany({
       where: { category: 'film' },
       take: 12,
-      orderBy: { id: 'desc' },
+      orderBy: { order: 'desc' },
     }),
     short: await client.works.findMany({
       where: { category: 'short' },
       take: 12,
-      orderBy: { id: 'desc' },
+      orderBy: { order: 'desc' },
     }),
     outsource: await client.works.findMany({
       where: { category: 'outsource' },
       take: 12,
-      orderBy: { id: 'desc' },
+      orderBy: { order: 'desc' },
     }),
   };
+  console.log(initialWorks);
   let initialHasNextPage = { film: false, short: false, outsource: false };
   for (const count in initialWorks) {
     initialWorks[count as VideosCategory].length < 12

--- a/src/pages/work/sort.tsx
+++ b/src/pages/work/sort.tsx
@@ -473,7 +473,7 @@ const VideoGridItem = ({
           <VideoItemTitle category={category} title={title} kind={kind} />
           <div className="font-light break-words text-[#606060]">
             <span className="whitespace-nowrap">OriginalOrder : </span>
-            <span className="text-[#999999] font-semibold">{order}</span>
+            <span className="text-[#999999] font-semibold">{currentSwapItem?.originalOrder}</span>
           </div>
         </div>
       </div>

--- a/src/pages/work/sort.tsx
+++ b/src/pages/work/sort.tsx
@@ -13,7 +13,7 @@ import PostManagementLayout from '@/components/nav/postManagementLayout';
 import SearchForm from '@/components/searchForm';
 import client from '@/libs/server/client';
 import PostManagementMenu from '@/components/nav/postManagementMenu';
-import { FlatformsCategory, VideoCollection, VideoResponseState } from '@/pages/work/work';
+import { VideoCategory, VideoCollection, VideoResponseState } from '@/pages/work/work';
 import { Works } from '@prisma/client';
 import { ciIncludes, cls, normalizeLeadingZero } from '@/libs/client/utils';
 import { useInfiniteScroll } from '@/libs/client/useInfiniteScroll';
@@ -112,7 +112,7 @@ const VideoItemInput = ({
 };
 
 interface VideoItemTitleProps {
-  category: FlatformsCategory;
+  category: VideoCategory;
   kind: string;
   title: string;
 }
@@ -225,7 +225,7 @@ const DragArea = ({
 interface VideoListItemProps {
   idx: number;
   video: WorksUsedInSort;
-  category: FlatformsCategory;
+  category: VideoCategory;
   selectedItem: SelectedItem | undefined;
   currentSwapItem: IdWithOrder | undefined;
   isDraggable: boolean;
@@ -337,7 +337,7 @@ const VideoListItem = ({
                   <Thumbnail
                     category={category}
                     src={
-                      category === 'filmShort'
+                      category === 'film' || category === 'short'
                         ? {
                             main: `${thumbnailLink}_640x360?r=pad`,
                             sub: `${thumbnailLink}_640x360?r=pad`,
@@ -362,7 +362,7 @@ const VideoListItem = ({
 
 interface VideoGridItemProps {
   video: WorksUsedInSort;
-  category: FlatformsCategory;
+  category: VideoCategory;
   selectedItem: SelectedItem | undefined;
   currentSwapItem: IdWithOrder | undefined;
   isDraggable: boolean;
@@ -448,7 +448,7 @@ const VideoGridItem = ({
         <Thumbnail
           category={category}
           src={
-            category === 'filmShort'
+            category === 'film' || category === 'short'
               ? {
                   main: `${thumbnailLink}_640x360?r=pad`,
                   sub: `${thumbnailLink}_640x360?r=pad`,
@@ -483,11 +483,11 @@ const VideoGridItem = ({
 
 interface VideoItemProps {
   video: WorksUsedInSort;
-  category: FlatformsCategory;
+  category: VideoCategory;
   isGrid: boolean;
   idx: number;
-  selectedList: SelectedItem[];
-  setSelectedList: Dispatch<SetStateAction<SelectedItem[]>>;
+  sortedList: SelectedItem[];
+  setSortedList: Dispatch<SetStateAction<SelectedItem[]>>;
   setSwapItems: Dispatch<SetStateAction<IdWithOrder[]>>;
   swapItems: IdWithOrder[];
   isDraggable: boolean;
@@ -499,22 +499,23 @@ const VideoItem = ({
   category,
   isGrid,
   idx,
-  selectedList,
-  setSelectedList,
+  sortedList,
+  setSortedList,
   setSwapItems,
   swapItems,
   isDraggable,
   setIsDraggable,
 }: VideoItemProps) => {
-  const selectedItem = selectedList.find((item) => item.id === video.id);
+  const selectedItem = sortedList.find((item) => item.id === video.id);
   const currentSwapItem = swapItems.find((item) => item.id === video.id);
+
   const [isDragging, setIsDragging] = useState(false);
   const [isDraggingOver, setIsDraggingOver] = useState<{ left: boolean; right: boolean }>({
     left: false,
     right: false,
   });
   const onThumbnailClick = (video: WorksUsedInSort) => {
-    setSelectedList((p) => {
+    setSortedList((p) => {
       const matchedSwapItem = swapItems.find((item) => item.id === video.id);
       return selectedItem
         ? p.filter((item) => item.id !== video.id)
@@ -528,9 +529,8 @@ const VideoItem = ({
     });
   };
   const onVideoDrop = () => {
-    console.log(!!currentSwapItem, !!isDraggable);
     if (!currentSwapItem || !isDraggable) return;
-    const sortedSelectedList = selectedList.sort((a, b) => b.currentOrder - a.currentOrder);
+    const sortedSelectedList = sortedList.sort((a, b) => b.currentOrder - a.currentOrder);
     const videoSort = (items: IdWithOrder[], position: 'left' | 'right') => {
       return items.map((item) => {
         const matchedIndex = sortedSelectedList.findIndex((listItem) => listItem.id === item.id);
@@ -545,24 +545,24 @@ const VideoItem = ({
               currentOrder:
                 // 드롭하려는 위치
                 targetOrder -
-                // selectedList내부의 order값 순서대로 그대로 옮기기 위해 order값 순서만큼 감산
+                // sortedt내부의 order값 순서대로 그대로 옮기기 위해 order값 순서만큼 감산
                 matchedIndex +
                 // 드롭하려는 위치보다 앞에서 아이템이 빠졌을 경우, 해당 아이템 수만큼 가산해서 드롭하려는 위치 조정
-                selectedList.filter((listItem) => listItem.currentOrder > targetOrder).length,
+                sortedList.filter((listItem) => listItem.currentOrder > targetOrder).length,
             };
           case item.currentOrder > targetOrder:
             return {
               ...item,
               currentOrder:
                 item.currentOrder +
-                selectedList.filter((listItem) => listItem.currentOrder > item.currentOrder).length,
+                sortedList.filter((listItem) => listItem.currentOrder > item.currentOrder).length,
             };
           case item.currentOrder <= targetOrder:
             return {
               ...item,
               currentOrder:
                 item.currentOrder -
-                selectedList.filter((listItem) => listItem.currentOrder < item.currentOrder).length,
+                sortedList.filter((listItem) => listItem.currentOrder < item.currentOrder).length,
             };
           default:
             return item;
@@ -576,7 +576,7 @@ const VideoItem = ({
     } else {
       return;
     }
-    setSelectedList([]);
+    setSortedList([]);
   };
   return (
     <>
@@ -621,11 +621,11 @@ const VideoItem = ({
 };
 
 interface VideoFeedProps {
-  category: FlatformsCategory;
+  category: VideoCategory;
   searchResult: VideoCollection<WorksUsedInSort[]>;
   setSearchResult: Dispatch<SetStateAction<VideoCollection<WorksUsedInSort[]>>>;
-  selectedList: SelectedItem[];
-  setSelectedList: Dispatch<SetStateAction<SelectedItem[]>>;
+  sortedList: SelectedItem[];
+  setSortedList: Dispatch<SetStateAction<SelectedItem[]>>;
   isGrid: boolean;
   page: number;
   swapItems: IdWithOrder[];
@@ -634,8 +634,8 @@ interface VideoFeedProps {
 
 const VideoFeed = ({
   searchResult,
-  selectedList,
-  setSelectedList,
+  sortedList,
+  setSortedList,
   category,
   isGrid,
   page,
@@ -671,8 +671,8 @@ const VideoFeed = ({
             video={video}
             isGrid={isGrid}
             idx={index}
-            selectedList={selectedList}
-            setSelectedList={setSelectedList}
+            sortedList={sortedList}
+            setSortedList={setSortedList}
             setSwapItems={setSwapItems}
             swapItems={swapItems}
             isDraggable={isDraggable}
@@ -685,11 +685,11 @@ const VideoFeed = ({
 };
 
 interface ChangedItemsModal {
-  setIsSelectedListOpen: Dispatch<SetStateAction<boolean>>;
+  setIsSortedListOpen: Dispatch<SetStateAction<boolean>>;
   changedSwapItems: IdWithOrder[];
 }
 
-const ChangedItemsModal = ({ changedSwapItems, setIsSelectedListOpen }: ChangedItemsModal) => {
+const ChangedItemsModal = ({ changedSwapItems, setIsSortedListOpen }: ChangedItemsModal) => {
   return (
     <div className="fixed z-[1001] top-0 left-0 w-screen h-screen xl:px-48 sm:px-32 px-24 py-32">
       <div className="absolute top-0 left-0 w-full h-full bg-black opacity-80" />
@@ -697,7 +697,7 @@ const ChangedItemsModal = ({ changedSwapItems, setIsSelectedListOpen }: ChangedI
         <button
           className="absolute m-2 top-4 right-4"
           onClick={() => {
-            setIsSelectedListOpen(false);
+            setIsSortedListOpen(false);
           }}
         >
           <svg
@@ -758,28 +758,25 @@ export default function Sort({
 }: InitialData) {
   const topElementRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
-  const [category, setCategory] = useState<FlatformsCategory>('filmShort');
+  const [category, setCategory] = useState<VideoCategory>('film');
   const [videoList, setVideoList] = useState(initialWorks);
   const [searchWord, setSearchWord] = useState('');
   const [searchWordSnapShot, setSearchWordSnapShot] = useState('');
   const [searchResult, setSearchResult] =
     useState<VideoCollection<WorksUsedInSort[]>>(initialWorks);
-  const [selectedList, setSelectedList] = useState<SelectedItem[]>([]);
+  const [sortedList, setSortedList] = useState<SelectedItem[]>([]);
   const [hasNextPage, setHasNextPage] = useState<VideoCollection<boolean>>(initialHasNextPage);
   const [isGrid, setIsGrid] = useState(true);
   const [fetchLoading, setFetchLoading] = useState(false);
-  const [isSelectedListOpen, setIsSelectedListOpen] = useState(false);
+  const [isSortedListOpen, setIsSortedListOpen] = useState(false);
   const [page, setPage] = useState(1);
-  const [apiPage, setApiPage] = useState<{
-    filmShort: number;
-    outsource: number;
-  }>({ filmShort: 1, outsource: 1 });
+  const [apiPage, setApiPage] = useState<Record<VideoCategory, number>>({
+    film: 1,
+    short: 1,
+    outsource: 1,
+  });
   const [swapItems, setSwapItems] = useState<IdWithOrder[]>(idWithOrderByCategory[category]);
   const perPage = 12;
-  const onCategoryClick = (categoryLabel: FlatformsCategory) => {
-    if (category === categoryLabel) return;
-    setCategory(categoryLabel);
-  };
   const [sendItems, { loading, data, error }] = useMutation<{ success: boolean }>(
     `/api/work?purpose=sort`
   );
@@ -800,26 +797,23 @@ export default function Sort({
     e.preventDefault();
     setPage(1); // page 부분이 2부터 시작할 필요가 있는지 살피고 수정 필요
     setSearchWordSnapShot(searchWord);
-    const currentList = isSelectedListOpen ? selectedList : videoList[category]; // 뻐킹 상상치도 못한방법
+    /* const currentList = isSortedListOpen ? sortedList : videoList[category]; */ // 뻐킹 상상치도 못한방법은 이제 과거로
     setSearchResult((p) => ({
       ...p,
-      [category]: currentList.filter((li) => ciIncludes(li.title, searchWord)),
+      [category]: videoList[category].filter((li) => ciIncludes(li.title, searchWord)),
     }));
   };
-  const commonReset = () => {
+  const commonReset = (newCategory: VideoCategory) => {
     setPage(1);
     setSearchWord('');
     setSearchWordSnapShot('');
-    setSelectedList([]);
-    setSearchResult((p) => ({ ...p, [category]: videoList[category] }));
-    setSwapItems(idWithOrderByCategory[category]);
+    setSortedList([]);
+    setSearchResult((p) => ({ ...p, [newCategory]: videoList[newCategory] }));
+    setSwapItems(idWithOrderByCategory[newCategory]);
   };
-  useEffect(() => {
-    commonReset();
-  }, [category]);
   const onResetClick = () => {
     if (changedSwapItems.length > 0) {
-      commonReset();
+      commonReset(category);
       topElementRef.current?.scrollIntoView();
     }
   };
@@ -828,24 +822,24 @@ export default function Sort({
       setFetchLoading(true);
       const response: VideoResponseState = await (
         await fetch(
-          `/api/work/list?page=${apiPage[category] + 1}&per_page=${perPage}&category=${category}`
+          `/api/work/list?page=${
+            apiPage[category] + 1
+          }&per_page=${perPage}&category=${category}$order=desc`
         )
       ).json();
-      const convertedCategory = category === 'filmShort' ? 'film' : 'outsource';
-      if (response.works[convertedCategory].length < perPage) {
+
+      if (response.works[category].length < perPage) {
         setHasNextPage((p) => ({ ...p, [category]: false }));
       }
       setVideoList((p) => ({
         ...p,
-        [category]: [...p[category], ...response.works[convertedCategory]],
+        [category]: [...p[category], ...response.works[category]],
       }));
       setSearchResult((p) => ({
         ...p,
         [category]: [
           ...p[category],
-          ...response.works[convertedCategory].filter((work) =>
-            ciIncludes(work.title, searchWordSnapShot)
-          ),
+          ...response.works[category].filter((work) => ciIncludes(work.title, searchWordSnapShot)),
         ],
       }));
       setApiPage((p) => ({ ...p, [category]: p[category] + 1 }));
@@ -855,7 +849,7 @@ export default function Sort({
     if (
       searchResult[category].length <= page * perPage &&
       hasNextPage[category] &&
-      !isSelectedListOpen
+      !isSortedListOpen
     ) {
       getVideos();
     }
@@ -871,9 +865,14 @@ export default function Sort({
     processIntersection,
     dependencyArray: [page, isGrid],
   });
-  const onSelectedListClick = () => {
-    setIsSelectedListOpen((p) => !p);
+  const onSortedListClick = () => {
+    setIsSortedListOpen((p) => !p);
   };
+
+  const onCategoryChange = (categoryLabel: VideoCategory) => {
+    commonReset(categoryLabel);
+  };
+
   return (
     <Layout
       seoTitle="SORT"
@@ -886,9 +885,15 @@ export default function Sort({
     >
       <PostManagementLayout
         category={category}
-        onCategoryClick={onCategoryClick}
+        tabs={[
+          { category: 'film', name: 'Film' },
+          { category: 'short', name: 'Short' },
+          { category: 'outsource', name: 'Outsource' },
+        ]}
         title="정렬하기"
         topElementRef={topElementRef}
+        setCategory={setCategory}
+        reset={onCategoryChange}
       >
         <SearchForm
           onSearch={onSearchSubmit}
@@ -901,8 +906,8 @@ export default function Sort({
           page={page}
           searchResult={searchResult}
           setSearchResult={setSearchResult}
-          selectedList={selectedList}
-          setSelectedList={setSelectedList}
+          sortedList={sortedList}
+          setSortedList={setSortedList}
           swapItems={swapItems}
           setSwapItems={setSwapItems}
         />
@@ -911,8 +916,8 @@ export default function Sort({
             setIsGrid((p) => !p);
           }}
           isGrid={isGrid}
-          onListClick={onSelectedListClick}
-          onSelectedList={isSelectedListOpen}
+          onListClick={onSortedListClick}
+          onSelectedList={isSortedListOpen}
           count={changedSwapItems.length}
           useOnMobile={true}
           listLabel="Diff"
@@ -920,21 +925,21 @@ export default function Sort({
         <ButtonsController
           onResetClick={onResetClick}
           onSaveClick={onSubmitSort}
-          onListClick={onSelectedListClick}
+          onListClick={onSortedListClick}
           onViewSwitch={() => {
             setIsGrid((p) => !p);
           }}
           isGrid={isGrid}
-          onSelectedList={isSelectedListOpen}
+          onSelectedList={isSortedListOpen}
           count={changedSwapItems.length}
           action="save"
           listLabel="Diff"
         />
         <div ref={intersectionRef} className="h-1 mt-20" />
-        {isSelectedListOpen ? (
+        {isSortedListOpen ? (
           <ChangedItemsModal
             changedSwapItems={changedSwapItems}
-            setIsSelectedListOpen={setIsSelectedListOpen}
+            setIsSortedListOpen={setIsSortedListOpen}
           />
         ) : null}
         {loading ? <LoaidngIndicator /> : null}
@@ -955,8 +960,13 @@ export default function Sort({
 
 export const getServerSideProps: GetServerSideProps = async () => {
   const initialWorks = {
-    filmShort: await client.works.findMany({
-      where: { OR: [{ category: 'film' }, { category: 'short' }] },
+    film: await client.works.findMany({
+      where: { category: 'film' },
+      take: 12,
+      orderBy: { order: 'desc' },
+    }),
+    short: await client.works.findMany({
+      where: { category: 'short' },
       take: 12,
       orderBy: { order: 'desc' },
     }),
@@ -966,16 +976,23 @@ export const getServerSideProps: GetServerSideProps = async () => {
       orderBy: { order: 'desc' },
     }),
   };
-  let initialHasNextPage = { filmShort: false, outsource: false };
-  for (const count in initialWorks) {
-    initialWorks[count as FlatformsCategory].length < 12
-      ? (initialHasNextPage[count as FlatformsCategory] = false)
-      : (initialHasNextPage[count as FlatformsCategory] = true);
+  let initialHasNextPage = { film: false, short: false, outsource: false };
+  for (const key in initialWorks) {
+    initialWorks[key as VideoCategory].length < 12
+      ? (initialHasNextPage[key as VideoCategory] = false)
+      : (initialHasNextPage[key as VideoCategory] = true);
   }
   const idWithOrderByCategory = {
-    filmShort: (
+    film: (
       await client.works.findMany({
-        where: { OR: [{ category: 'film' }, { category: 'short' }] },
+        where: { category: 'film' },
+        select: { id: true, order: true },
+        orderBy: { order: 'desc' },
+      })
+    ).map((item) => ({ id: item.id, currentOrder: item.order, originalOrder: item.order })),
+    short: (
+      await client.works.findMany({
+        where: { category: 'short' },
         select: { id: true, order: true },
         orderBy: { order: 'desc' },
       })

--- a/src/pages/work/work.d.ts
+++ b/src/pages/work/work.d.ts
@@ -1,6 +1,12 @@
-export interface VideoCollection<T, U = T> {
+export interface FlatformCollection<T, U = T> {
   filmShort: T;
   outsource: U;
+}
+
+export interface VideoCollection<T, U = T, G = T> {
+  film: T;
+  short: U;
+  outsource: G;
 }
 
 export interface WorkInfosWithId extends WorkInfos {
@@ -16,7 +22,7 @@ export interface WorkInfos {
   title: string;
   description: string;
   resourceId: string;
-  category: string;
+  category: VideoCategory;
   date: string;
   thumbnailLink: string;
   animatedThumbnailLink: string;
@@ -34,8 +40,9 @@ export interface VimeoVideos {
 }
 
 export interface OwnedVideoItems {
+  id: number;
   title: string;
-  category: VideosCategory;
+  category: VideoCategory;
   date: string;
   description: string;
   resourceId: string;

--- a/src/pages/work/write.tsx
+++ b/src/pages/work/write.tsx
@@ -19,7 +19,7 @@ import {
   FlatformsCategory,
   OwnedVideoItems,
   VideoCategory,
-  VideoCollection,
+  FlatformCollection,
   VimeoVideos,
   WorkInfos,
 } from '@/pages/work/work';
@@ -30,7 +30,7 @@ import ErrorOverlay from '@/components/errorOverlay';
 interface InitialData {
   initialVimeoVideos: VimeoVideos[];
   initialYoutubeVideos: GapiItem[];
-  initialOwnedVideos: VideoCollection<OwnedVideoItems[]>;
+  initialOwnedVideos: FlatformCollection<OwnedVideoItems[]>;
   initialNextPageToken: string;
 }
 
@@ -45,14 +45,16 @@ export default function Write({
   const [category, setCategory] = useState<FlatformsCategory>('filmShort');
   const [searchWord, setSearchWord] = useState('');
   const [searchWordSnapshot, setSearchWordSnapshot] = useState('');
-  const [searchResults, setSearchResults] = useState<VideoCollection<VimeoVideos[], GapiItem[]>>({
-    filmShort: initialVimeoVideos,
-    outsource: initialYoutubeVideos,
-  });
+  const [searchResults, setSearchResults] = useState<FlatformCollection<VimeoVideos[], GapiItem[]>>(
+    {
+      filmShort: initialVimeoVideos,
+      outsource: initialYoutubeVideos,
+    }
+  );
   const [searchResultsSnapshot, setSearchResultsSnapshot] = useState<
-    VideoCollection<VimeoVideos[], GapiItem[]>
+    FlatformCollection<VimeoVideos[], GapiItem[]>
   >({ filmShort: [], outsource: [] });
-  const [list, setList] = useState<VideoCollection<VimeoVideos[], GapiItem[]>>({
+  const [list, setList] = useState<FlatformCollection<VimeoVideos[], GapiItem[]>>({
     filmShort: initialVimeoVideos,
     outsource: initialYoutubeVideos,
   });
@@ -61,7 +63,7 @@ export default function Write({
   }>(`/api/work?purpose=write`);
   const [workInfos, setWorkInfos] = useState<WorkInfos[]>([]);
   const [fetchLoading, setFetchLoading] = useState(false);
-  const ownedVideos: VideoCollection<OwnedVideoItems[]> = initialOwnedVideos;
+  const ownedVideos: FlatformCollection<OwnedVideoItems[]> = initialOwnedVideos;
   const [page, setPage] = useState(2);
   const [onSelectedList, setOnSelectedList] = useState(false);
   const [isGrid, setIsGrid] = useState(true);

--- a/src/pages/work/write.tsx
+++ b/src/pages/work/write.tsx
@@ -85,6 +85,7 @@ export default function Write({
     if (data && data?.success) {
       router.push('/work');
     } else if (data && !data?.success) {
+      console.log(error);
       const timeOut = setTimeout(() => {
         router.push('/work');
       }, 3000);
@@ -193,18 +194,16 @@ export default function Write({
         .map((item, index, arr) => ({ ...item, order: arr.length - index }));
     };
 
-    const newVideos = {
-      film: sortVideos(newWorkInfos, 'film'),
-      short: sortVideos(newWorkInfos, 'short'),
-      outsource: sortVideos(newWorkInfos, 'outsource'),
-    };
+    const newVideos = [
+      ...sortVideos(newWorkInfos, 'film'),
+      ...sortVideos(newWorkInfos, 'short'),
+      ...sortVideos(newWorkInfos, 'outsource'),
+    ];
 
-    console.log(newVideos);
-
-    /* sendList({
-      data: newWorkInfos,
+    sendList({
+      data: newVideos,
       secret: process.env.NEXT_PUBLIC_ODR_SECRET_TOKEN,
-    }); */
+    });
   };
 
   const onSearch = (e: SyntheticEvent<HTMLFormElement>) => {

--- a/src/pages/work/write.tsx
+++ b/src/pages/work/write.tsx
@@ -301,8 +301,8 @@ export default function Write({
     }
   };
 
-  const onCategoryChange = () => {
-    const oppositeCategory = category === 'filmShort' ? 'outsource' : 'filmShort';
+  const onCategoryChange = (categoryLabel: FlatformsCategory) => {
+    const oppositeCategory = categoryLabel === 'filmShort' ? 'outsource' : 'filmShort';
     setOnSelectedList(false);
     setWorkInfos([]);
     setPage(2);


### PR DESCRIPTION
1. 정렬하기 페이지의 정렬 카테고리를 film, short, outsource의 3개로 분리
2. 정렬기준으로 order 필드의 값을 사용하도록 수정
3. 작성하기 페이지 filmShort 탭에서 기존 데이터의 카테고리를 변경했을 때 순서 변경과 재정렬 적용